### PR TITLE
Format floats to allow for very large/small values

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -160,6 +160,30 @@ func TestKeys(t *testing.T) {
 			Expected: "FSET agent 47 XX cash 100500",
 		},
 		{
+			Cmd: keys.FSet("agent", "47").
+				Field("id", 123456789012345680).
+				IfExists().toCmd(),
+			Expected: "FSET agent 47 XX id 123456789012345680",
+		},
+		{
+			Cmd: keys.FSet("agent", "47").
+				Field("id", -123456789012345680).
+				IfExists().toCmd(),
+			Expected: "FSET agent 47 XX id -123456789012345680",
+		},
+		{
+			Cmd: keys.FSet("agent", "47").
+				Field("small", 0.00000000012345678901234568).
+				IfExists().toCmd(),
+			Expected: "FSET agent 47 XX small 0.00000000012345678901234568",
+		},
+		{
+			Cmd: keys.FSet("agent", "47").
+				Field("small", -0.00000000012345678901234568).
+				IfExists().toCmd(),
+			Expected: "FSET agent 47 XX small -0.00000000012345678901234568",
+		},
+		{
 			Cmd:      keys.JSet("foo", "bar", "some.field", "some-value").Raw().toCmd(),
 			Expected: "JSET foo bar some.field some-value RAW",
 		},

--- a/utils.go
+++ b/utils.go
@@ -25,7 +25,7 @@ func (c cmd) String() string {
 }
 
 func floatString(val float64) string {
-	return strconv.FormatFloat(val, 'g', 10, 64)
+	return strconv.FormatFloat(val, 'f', -1, 64)
 }
 
 func rawEventHandler(handler func(*GeofenceEvent)) func([]byte) error {


### PR DESCRIPTION
This is to resolve issue 51 https://github.com/shadowspore/t38c/issues/51

Using `strconv.FormatFloat(val, 'g', 10, 64)` to format floats means that very large or very small numbers will be rounded. For example, a value of 123456789012345680 will be saved as 123456789000000000. By using -1 for precision means the smallest number of digits will be used to represent a float exactly.