### PR TITLE
Add function RawQuery to support filter expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/xjem/t38c"
+	"github.com/sythang/t38c"
 )
 
 func main() {

--- a/client.go
+++ b/client.go
@@ -101,7 +101,7 @@ func (client *Client) jExecute(ctx context.Context, resp interface{}, command st
 func (client *Client) Execute(ctx context.Context, command string, args ...string) ([]byte, error) {
 	resp, err := client.exec.Execute(ctx, command, args...)
 	if client.debug {
-		log.Printf("[%s]: %s", newCmd(command, args...).String(), resp)
+		log.Printf("\033[34m[%s]\u001B[0m: \u001B[32m%s\u001B[0m", newCmd(command, args...).String(), resp)
 	}
 
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/sythang/t38c/transport"
 	"github.com/tidwall/gjson"
-	"github.com/xjem/t38c/transport"
 )
 
 // Client allows you to interact with the Tile38 server.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/xjem/t38c"
+	"github.com/sythang/t38c"
 )
 
 func TestE2E(t *testing.T) {

--- a/e2e/geofence_test.go
+++ b/e2e/geofence_test.go
@@ -10,7 +10,7 @@ import (
 
 	geojson "github.com/paulmach/go.geojson"
 	"github.com/stretchr/testify/require"
-	"github.com/xjem/t38c"
+	"github.com/sythang/t38c"
 )
 
 func testGeofence(t *testing.T, client *t38c.Client) {

--- a/e2e/keys_get_test.go
+++ b/e2e/keys_get_test.go
@@ -7,7 +7,7 @@ import (
 
 	geojson "github.com/paulmach/go.geojson"
 	"github.com/stretchr/testify/require"
-	"github.com/xjem/t38c"
+	"github.com/sythang/t38c"
 )
 
 func testKeys(t *testing.T, client *t38c.Client) {

--- a/e2e/within_test.go
+++ b/e2e/within_test.go
@@ -6,7 +6,7 @@ import (
 
 	geojson "github.com/paulmach/go.geojson"
 	"github.com/stretchr/testify/require"
-	"github.com/xjem/t38c"
+	"github.com/sythang/t38c"
 )
 
 func testWithin(t *testing.T, client *t38c.Client) {

--- a/examples/basic.go
+++ b/examples/basic.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/xjem/t38c"
+	"github.com/sythang/t38c"
 )
 
 func main() {

--- a/examples/fields.go
+++ b/examples/fields.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/xjem/t38c"
+	"github.com/sythang/t38c"
 )
 
 func main() {

--- a/examples/filter_json_field.go
+++ b/examples/filter_json_field.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"context"
+	geojson "github.com/paulmach/go.geojson"
+	"github.com/xjem/t38c"
+	"log"
+)
+
+func main() {
+	tile38, err := t38c.New(t38c.Config{
+		Address: "localhost:9851",
+		Debug:   true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer tile38.Close()
+	feature := geojson.NewPointFeature([]float64{33.5123, -112.2693})
+	feature.Properties = map[string]interface{}{
+		"speed": 55,
+		"name":  "Carol",
+		"age":   "23",
+	}
+	f2 := geojson.NewPointFeature([]float64{33.553653, -112.112222})
+	f2.Properties = map[string]interface{}{
+		"speed": 40,
+		"name":  "Andy",
+		"age":   "25",
+	}
+	tile38.Keys.Set("fleet", "carol").Feature(feature).Do(context.Background())
+	tile38.Keys.Set("fleet", "andy").Feature(f2).Do(context.Background())
+
+	// references: https://tile38.com/topics/filter-expressions
+	tile38.Search.Scan("fleet").RawQuery("properties.age == 25 && properties.speed > 50").Do(context.Background())
+}

--- a/examples/filter_json_field.go
+++ b/examples/filter_json_field.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	geojson "github.com/paulmach/go.geojson"
-	"github.com/xjem/t38c"
+	"github.com/sythang/t38c"
 	"log"
 )
 

--- a/examples/flush_db.go
+++ b/examples/flush_db.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/xjem/t38c"
+	"github.com/sythang/t38c"
 )
 
 /*

--- a/examples/geofencing.go
+++ b/examples/geofencing.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/xjem/t38c"
+	"github.com/sythang/t38c"
 )
 
 func main() {

--- a/examples/object_types.go
+++ b/examples/object_types.go
@@ -8,7 +8,7 @@ import (
 	"log"
 
 	geojson "github.com/paulmach/go.geojson"
-	"github.com/xjem/t38c"
+	"github.com/sythang/t38c"
 )
 
 func main() {

--- a/examples/pubsub.go
+++ b/examples/pubsub.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/xjem/t38c"
+	"github.com/sythang/t38c"
 )
 
 func main() {

--- a/examples/searching.go
+++ b/examples/searching.go
@@ -10,7 +10,7 @@ import (
 	"log"
 	"math"
 
-	"github.com/xjem/t38c"
+	"github.com/sythang/t38c"
 )
 
 func main() {

--- a/executor.go
+++ b/executor.go
@@ -3,7 +3,7 @@ package t38c
 import (
 	"context"
 
-	"github.com/xjem/t38c/transport"
+	"github.com/sythang/t38c/transport"
 )
 
 var _ Executor = (*transport.Radix)(nil)

--- a/geofence_query_builder.go
+++ b/geofence_query_builder.go
@@ -207,3 +207,12 @@ func (query GeofenceQueryBuilder) Format(fmt OutputFormat) GeofenceQueryBuilder 
 	query.outputFormat = &fmt
 	return query
 }
+
+// RawQuery is similar to a Where clause, but it allows for the input of a raw query.
+// As of Tile38 1.30.0 FIELD is no longer limited to numbers.
+// Example can be searched for with `SCAN fleet WHERE driver.firstname == Josh IDS`
+// or `INTERSECTS fleet WHERE 'info.speed > 45 && info.age < 21' BOUNDS 30 -120 40 -100`
+func (query GeofenceQueryBuilder) RawQuery(rawQuery string) GeofenceQueryBuilder {
+	query.searchOpts.RawQuery = append(query.searchOpts.RawQuery, rawQuery)
+	return query
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/xjem/t38c
+module github.com/sythang/t38c
 
 go 1.14
 

--- a/inw_query_builder.go
+++ b/inw_query_builder.go
@@ -149,3 +149,12 @@ func (query InwQueryBuilder) Format(fmt OutputFormat) InwQueryBuilder {
 	query.outputFormat = &fmt
 	return query
 }
+
+// RawQuery is similar to a Where clause, but it allows for the input of a raw query.
+// As of Tile38 1.30.0 FIELD is no longer limited to numbers.
+// Example can be searched for with `SCAN fleet WHERE driver.firstname == Josh IDS`
+// or `INTERSECTS fleet WHERE 'info.speed > 45 && info.age < 21' BOUNDS 30 -120 40 -100`
+func (query InwQueryBuilder) RawQuery(rawQuery string) InwQueryBuilder {
+	query.searchOpts.RawQuery = append(query.searchOpts.RawQuery, rawQuery)
+	return query
+}

--- a/scan_query_builder.go
+++ b/scan_query_builder.go
@@ -104,3 +104,12 @@ func (query ScanQueryBuilder) Format(fmt OutputFormat) ScanQueryBuilder {
 	query.outputFormat = &fmt
 	return query
 }
+
+// RawQuery is similar to a Where clause, but it allows for the input of a raw query.
+// As of Tile38 1.30.0 FIELD is no longer limited to numbers.
+// Example can be searched for with `SCAN fleet WHERE driver.firstname == Josh IDS`
+// or `INTERSECTS fleet WHERE 'info.speed > 45 && info.age < 21' BOUNDS 30 -120 40 -100`
+func (query ScanQueryBuilder) RawQuery(rawQuery string) ScanQueryBuilder {
+	query.opts.RawQuery = append(query.opts.RawQuery, rawQuery)
+	return query
+}

--- a/search_opts.go
+++ b/search_opts.go
@@ -32,11 +32,16 @@ type searchOpts struct {
 	Wherein   []whereinOpt
 	Match     []string
 	WhereEval []whereEvalOpt
+	RawQuery  []string
 }
 
 func (opts searchOpts) Args() (args []string) {
 	for _, opt := range opts.Where {
 		args = append(args, "WHERE", opt.Field, floatString(opt.Min), floatString(opt.Max))
+	}
+
+	for _, opt := range opts.RawQuery {
+		args = append(args, "WHERE", opt)
 	}
 
 	for _, opt := range opts.Wherein {

--- a/search_query_builder.go
+++ b/search_query_builder.go
@@ -106,3 +106,12 @@ func (query SearchQueryBuilder) FormatIDs() SearchQueryBuilder {
 	query.outputFormat = &FormatIDs
 	return query
 }
+
+// RawQuery is similar to a Where clause, but it allows for the input of a raw query.
+// As of Tile38 1.30.0 FIELD is no longer limited to numbers.
+// Example can be searched for with `SCAN fleet WHERE driver.firstname == Josh IDS`
+// or `INTERSECTS fleet WHERE 'info.speed > 45 && info.age < 21' BOUNDS 30 -120 40 -100`
+func (query SearchQueryBuilder) RawQuery(rawQuery string) SearchQueryBuilder {
+	query.opts.RawQuery = append(query.opts.RawQuery, rawQuery)
+	return query
+}


### PR DESCRIPTION
Starting with v1.30, a FIELD can store more than just a number, and the WHERE clause supports expressions that filter on an object field or GeoJSON properties
I added a new function RawQuery is similar to a Where clause, but it allows for the input of a raw query.